### PR TITLE
Show message when nothing to display and changed scroll bar visibility.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -19,7 +19,7 @@
 .actions {
   flex-grow: 1;
   flex-shrink: 1;
-  overflow: scroll;
+  overflow: auto;
   padding: 8px 0;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -22,6 +22,13 @@
   overflow: auto;
   padding: 8px 0;
 }
+/* To display a message to the user when there are no actions */
+.actions:empty::after {
+  content: "Nothing to show here yet.";
+  display: flex;
+  justify-content: center;
+  padding: 8px 0;
+}
 
 .header, .footer {
   color: white;


### PR DESCRIPTION
Using the CSS pseudo-class :empty, it now shows a message when there is nothing to display.
When first opening the popup it is a bit confusing to have scrollbars in the X and Y direction. Now it won't show the Y scroll bar till it populates fully. Also, I don't think there is a case for the scroll X bar to show.
