### PR TITLE
Display messages alongside typings

### DIFF
--- a/src/Action.css
+++ b/src/Action.css
@@ -48,6 +48,10 @@
   border-radius: 50%;
 }
 
+.bar {
+  position: relative;
+}
+
 .typings {
   width: 100%;
   display: flex;
@@ -64,6 +68,32 @@
   transition: background-color 0.1s ease;
 }
 
+.typingOngoing {
+  background-color: green;
+}
+
 .typing:hover {
   background-color: rgba(0, 0, 0, 0.15);
+}
+
+.messages {
+  position: absolute;
+  top: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  align-self: stretch;
+  height: 7px;
+}
+
+.pauseIgnored {
+  pointer-events: none;
+}
+
+.message {
+  flex-shrink: 0;
+  width: 2px;
+  margin: -1px;
+  border-radius: 1px;
+  background-color: #3b5998;
 }

--- a/src/Action.jsx
+++ b/src/Action.jsx
@@ -1,11 +1,13 @@
 import React, { PropTypes } from 'react';
 import moment from 'moment';
 import cx from 'classnames';
+import last from 'lodash';
 
 import styles from './Action.css';
 
 function Action(props) {
   const { action, unread } = props;
+
   let lastEnd = 0;
   const typings = [];
   action.typings.forEach((typing, typingIdx) => {
@@ -25,9 +27,13 @@ function Action(props) {
         />
       );
     }
+
     typings.push(
       <div
-        className={styles.typing}
+        className={cx([
+          styles.typing,
+          typing.ongoing && styles.typingOngoing,
+        ])}
         title={
           `${Math.round((typing.endDate - typing.startDate) / 1000)}s – ` +
           `${moment(typing.startDate).format('HH:mm:ss')} to ` +
@@ -38,6 +44,61 @@ function Action(props) {
     );
     lastEnd = end;
   });
+
+  typings.push(
+    <div
+      className={styles.pause}
+      title={`${Math.round((action.endDate - lastEnd) / 1000)}s`}
+      style={{
+        width: action.endDate - last(action.typings).endDate,
+      }}
+    />
+  );
+
+  let lastDate = 0;
+  const messages = [];
+
+  if (action.messages.length > 0) {
+    messages.push(
+      <div
+        className={styles.pauseIgnored}
+        style={{
+          width: action.messages[0].timestamp - action.startDate,
+        }}
+      />
+    );
+  }
+
+  action.messages.forEach((message, messageIdx) => {
+    if (messageIdx !== 0) {
+      messages.push(
+        <div
+          className={styles.pauseIgnored}
+          style={{
+            width: message.timestamp - lastDate,
+          }}
+        />
+      );
+    }
+
+    messages.push(
+      <div
+        className={styles.message}
+        title={moment(message.timestamp).format('HH:mm:ss')}
+      />
+    );
+
+    lastDate = message.timestamp;
+  });
+
+  messages.push(
+    <div
+      className={styles.pauseIgnored}
+      style={{
+        width: action.endDate - lastDate,
+      }}
+    />
+  );
 
   return (
     <div
@@ -62,8 +123,13 @@ function Action(props) {
           }
         </div>
         <div className={styles.date}>{moment(action.endDate).fromNow()}</div>
-        <div className={styles.typings}>
-          {typings}
+        <div className={styles.bar}>
+          <div className={styles.typings}>
+            {typings}
+          </div>
+          <div className={styles.messages}>
+            {messages}
+          </div>
         </div>
       </div>
     </div>

--- a/src/hook.js
+++ b/src/hook.js
@@ -11,7 +11,6 @@ requireLazy(
       );
       MercuryThreads.get().getMultiThreadMeta(threadIds, threads => {
         ShortProfiles.getMulti(userIds, users => {
-          console.log('ok');
           window.postMessage({
             type: 'update',
             threads,

--- a/src/hook.js
+++ b/src/hook.js
@@ -1,8 +1,19 @@
 import getUserId from './getUserId';
 
 requireLazy(
-  ['MercuryTypingReceiver', 'MercuryThreads', 'ShortProfiles'],
-  (MercuryTypingReceiver, MercuryThreads, ShortProfiles) => {
+  ['MercuryTypingReceiver', 'MercuryThreads', 'ShortProfiles', 'MercuryThreadInformer'],
+  (MercuryTypingReceiver, MercuryThreads, ShortProfiles, MercuryThreadInformer) => {
+    MercuryThreadInformer.get().subscribe('messages-received', (m, newMessages) => {
+      const threadIds = Object.keys(newMessages);
+      const messages = threadIds.reduce(
+        (res, threadId) => res.concat(newMessages[threadId]),
+        []
+      );
+      window.postMessage({
+        type: 'update-messages',
+        messages,
+      }, '*');
+    });
     MercuryTypingReceiver.get().addRetroactiveListener('state-changed', state => {
       const threadIds = Object.keys(state);
       const userIds = threadIds.reduce(

--- a/src/inject.js
+++ b/src/inject.js
@@ -9,7 +9,7 @@ window.addEventListener('message', event => {
     return;
   }
 
-  if (event.data.type && (event.data.type === 'update')) {
+  if (event.data.type && (['update', 'update-messages'].indexOf(event.data.type) !== -1)) {
     chrome.runtime.sendMessage(event.data);
   }
 }, false);

--- a/src/popup.js
+++ b/src/popup.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import groupBy from 'lodash/groupBy';
+import sortBy from 'lodash/sortBy';
+import sortedIndexBy from 'lodash/sortedIndexBy';
 
 import App from './App';
+import getUserId from './getUserId';
 
 const container = document.getElementById('container');
 
@@ -14,15 +17,26 @@ const AGGREGATE_TIME = 30 * 60 * 1000;
 // while someone is typing.
 const IGNORE_LIMIT = 10 * 60 * 1000;
 
-function aggregate(actions) {
-  const byUserThread = groupBy(
-    actions,
-    a => `${a.thread.thread_id}/${a.user.id}`
+// Consider messages this close (in ms) to the last stopped_typing event to be
+// part of the overall action.
+const MESSAGE_LATENCY = 1 * 60 * 1000;
+
+function actionToThreadUser(a) {
+  return `${a.thread.thread_id}/${a.user.id}`;
+}
+
+function aggregate(actions, messages) {
+  const sortedMessages = sortBy(messages, 'timestamp');
+
+  const actionsByUserThread = groupBy(actions, actionToThreadUser);
+  const messagesByUserThread = groupBy(
+    sortedMessages,
+    m => `${m.thread_id}/${getUserId(m.author)}`
   );
 
   const aggregatedActions = [];
-  Object.keys(byUserThread).forEach(key => {
-    const utActions = byUserThread[key];
+  Object.keys(actionsByUserThread).forEach(key => {
+    const utActions = actionsByUserThread[key];
 
     let typings = [];
     let startDate = null;
@@ -74,14 +88,38 @@ function aggregate(actions) {
     }
   });
 
-  aggregatedActions.sort((a, b) => b.endDate - a.endDate);
-  return aggregatedActions;
+  const aggregatedActionsWithMessages = aggregatedActions.map(action => {
+    const threadMessages = messagesByUserThread[actionToThreadUser(action)];
+    if (!threadMessages) {
+      return {
+        ...action,
+        messages: [],
+      };
+    }
+    const firstMessageIndex = sortedIndexBy(
+      threadMessages,
+      { timestamp: action.startDate },
+      'timestamp'
+    );
+    const lastMessageIndex = sortedIndexBy(
+      threadMessages,
+      { timestamp: action.endDate + MESSAGE_LATENCY },
+      'timestamp'
+    );
+    return {
+      ...action,
+      messages: threadMessages.slice(firstMessageIndex, lastMessageIndex),
+    };
+  });
+
+  aggregatedActionsWithMessages.sort((a, b) => b.endDate - a.endDate);
+  return aggregatedActionsWithMessages;
 }
 
 function render(store) {
-  const { actions, lastReadDate = 0 } = store;
+  const { actions, messages, lastReadDate = 0 } = store;
 
-  const aggregatedActions = aggregate(actions);
+  const aggregatedActions = aggregate(actions, messages);
 
   ReactDOM.render(
     <App


### PR DESCRIPTION
This PR adds message indicators to the extension.

I decided not to go with colored typing bars since we can't reliably map a message to a typing event. 

![image](https://cloud.githubusercontent.com/assets/1621758/15712362/5afd7164-2812-11e6-892b-534223be7275.png)
