### PR TITLE
Show scrollbar on need basis

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -19,7 +19,7 @@
 .actions {
   flex-grow: 1;
   flex-shrink: 1;
-  overflow: scroll;
+  overflow: auto;
   padding: 8px 0;
 }
 


### PR DESCRIPTION
Hi there,

Currently in your extension scroll-bars are visible even if there is no need of it . See screenshot below :-
![image](https://cloud.githubusercontent.com/assets/10435209/15774697/5d9714b8-299b-11e6-9467-04b4f14816f8.png)

We can fix this issue by changing `overlow:scroll`l to `overflow:auto` in your App.css.

PS :- This is my first pull request on github . Please let me know is everything else is required for this  pull request.

Thanks & Regards,
Tarun Garg 
